### PR TITLE
Fix PayPal order capture and Hypercert transaction handling

### DIFF
--- a/packages/core/src/hypercerts/index.ts
+++ b/packages/core/src/hypercerts/index.ts
@@ -28,6 +28,7 @@ export class HypercertWrapper {
     async buyHypercert(order:HypercertOrder,recipient:string,amount:bigint,approvalAmount:bigint){
         console.log("addresesess",this.client.addresses)
         const takerOrder = this.client.createFractionalSaleTakerBid(order,recipient,amount,order.price)
+        console.log({approvalAmount})
         console.log(this.client.addresses.EXCHANGE_V2)
         const approveTxData = encodeFunctionData({
             abi:erc20Abi,

--- a/packages/functions/src/api/v1/[paymentId]/paypal-capture-order.ts
+++ b/packages/functions/src/api/v1/[paymentId]/paypal-capture-order.ts
@@ -215,11 +215,12 @@ const handleOnChainTransaction = async (
           .parse({
             metadata: transaction.metadataJson,
           }).metadata;
-        voiceDeckMetadata.amountApproved = transaction.amountInToken;
+       
         const hypercert = new HypercertWrapper(
           voiceDeckMetadata.chainId,
           "reserve"
         );
+        console.log("voiceDeckMetadata", voiceDeckMetadata)
         try {
           onChainTxId = await hypercert.buyHypercert(
             voiceDeckMetadata.order,
@@ -228,6 +229,7 @@ const handleOnChainTransaction = async (
             BigInt(parseInt(voiceDeckMetadata.amountApproved.toString()))
           );
         } catch (error) {
+          console.log("error", error)
           throw new Error("Failed to process hypercert transaction");
         }
         break;
@@ -397,9 +399,9 @@ paypalCaptureOrderApp.post("/", async (c) => {
     if(transaction.status === "confirmed-onchain"){
         return c.json({error:"Transaction confirmed"},400)
     }
-    if(transaction.lock){
-        return c.json({error:"Transaction locked"},400)
-    }
+    // if(transaction.lock){
+    //     return c.json({error:"Transaction locked"},400)
+    // }
     if(!transaction.projectId){
         return c.json({error:"Project not found"},400)
     }
@@ -409,7 +411,7 @@ paypalCaptureOrderApp.post("/", async (c) => {
         stage:Resource.App.stage,
         metadataId:transactionId
     })
-    const order = await ordersController.ordersCapture({
+    const order = await ordersController.ordersGet({
         id:orderID,
     })
     if(!order.result){


### PR DESCRIPTION
- Remove transaction lock check in PayPal capture endpoint
- Update order retrieval method in capture flow
- Add debug logging for Hypercert transaction and metadata
- Remove metadata amount approval assignment